### PR TITLE
Fix install dependencies section

### DIFF
--- a/guides/get-started/install.md
+++ b/guides/get-started/install.md
@@ -35,11 +35,11 @@ You can use your local machine to run the Ansible roles for remote targets, or y
 
 3. **Install Dependencies**
 
-   Install the required dependencies using npm:
+   Install the required dependencies using pip and ansible:
 
    ```sh
    pip3 install -r provisioning/ansible/requirements.txt
-   ansible-galaxy install -r provisioning/ansible/requirements.yml
+   ansible-galaxy install -r provisioning/ansible/requirements.yaml
    ```
 
 4. **Copy and Edit Configuration File**


### PR DESCRIPTION
The script runs pip and ansible, not npm. The ansible requirements extensions is wrong, the repo contains a **.yaml** file: https://github.com/newpush-labs/newpush-labs/blob/main/provisioning/ansible/requirements.yaml